### PR TITLE
Update dargon2 libraries

### DIFF
--- a/.github/workflows/dargon2_library-builder.yml
+++ b/.github/workflows/dargon2_library-builder.yml
@@ -40,7 +40,7 @@ jobs:
         git config user.email "GH-actions-ci@github.com"
         git add -f lib/src/blobs/libargon2-linux.so
         git commit -m "Create Native Library for Linux"
-        git push origin main
+        git push origin ${GITHUB_REF##*/}
   mac-build:
     runs-on: macos-latest
     needs: linux-build
@@ -78,7 +78,7 @@ jobs:
         git config user.email "GH-actions-ci@github.com"
         git add -f lib/src/blobs/libargon2-darwin.dylib
         git commit -m "Create Native Library for Mac"
-        git push origin main
+        git push origin ${GITHUB_REF##*/}
   windows-build:
     runs-on: windows-latest
     needs: [linux-build, mac-build]
@@ -119,5 +119,5 @@ jobs:
           git config user.email "GH-actions-ci@github.com"
           git add -f lib/src/blobs/libargon2-win.dll
           git commit -m "Create Native Library for Windows"
-          git push origin main
+          git push origin ${GITHUB_REF##*/}
         shell: bash

--- a/.github/workflows/dargon2_tests.yml
+++ b/.github/workflows/dargon2_tests.yml
@@ -19,6 +19,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: dart-lang/setup-dart@v1
     - name: Install dependencies
-      run: pub get
+      run: dart pub get
     - name: Run tests
-      run: pub run test
+      run: dart pub run test


### PR DESCRIPTION
#9 shows a failure in execution with the existing libraries on Ubuntu 20.04. This PR (when finalized) should fix that failure.