### PR TITLE
Fix the failed `dart run` command

### DIFF
--- a/dargon2/lib/src/native/dart_lib_loader.dart
+++ b/dargon2/lib/src/native/dart_lib_loader.dart
@@ -29,16 +29,11 @@ class DartLibLoader implements LibLoader {
   /// and the binary's relative path
   @override
   String getPath() {
-    String rootPath;
-    if (Platform.script.path.endsWith('.snapshot')) {
-      rootPath = File.fromUri(Platform.script).parent.path;
-    } else {
-      final rootLibrary = 'package:dargon2/dargon2.dart';
-      // ignore: deprecated_member_use
-      rootPath = waitFor(Isolate.resolvePackageUri(Uri.parse(rootLibrary)))!
+    final rootLibrary = 'package:dargon2/dargon2.dart';
+    // ignore: deprecated_member_use
+    var rootPath = waitFor(Isolate.resolvePackageUri(Uri.parse(rootLibrary)))!
           .resolve('src/blobs/')
           .toFilePath(windows: Platform.isWindows);
-    }
     if (Platform.isMacOS) return '${rootPath}libargon2-darwin.dylib';
     if (Platform.isLinux) return '${rootPath}libargon2-linux.so';
     if (Platform.isWindows) return '${rootPath}libargon2-win.dll';


### PR DESCRIPTION
`dart run` was broken when used without a file path, brought up in #8.

This should remove the snapshot portion that seemed to kick off when `dart run` was used without any file path.